### PR TITLE
Fixed problem where 'npm run prod' and 'npm run dev' failed

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -7,7 +7,7 @@ window.Vue = require('vue');
  */
 import ElementUI from 'element-ui'
 import locale from 'element-ui/lib/locale/lang/ja'
-import 'element-theme-default/theme/index.css'
+import 'element-theme-default/lib/index.css'
 Vue.use(ElementUI, {locale})
 
 /*

--- a/resources/views/mainboard.blade.php
+++ b/resources/views/mainboard.blade.php
@@ -5,7 +5,7 @@
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>jorro</title>
-  <link rel="stylesheet" href="css/app.css"/>
+  <link rel="stylesheet" href="{{ mix('css/app.css') }}"/>
   <script type="text/javascript">
       window.Laravel = window.Laravel || {};
       window.Laravel.csrfToken = "{{ csrf_token() }}";
@@ -20,7 +20,7 @@
   </main>
 </div>
 
-<script src="js/app.js"></script>
+<script src="{{ mix('js/app.js') }}"></script>
 
 </body>
 </html>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -12,5 +12,14 @@ const { mix } = require('laravel-mix');
  */
 
 mix.js('resources/assets/js/app.js', 'public/js')
-   .sass('resources/assets/sass/app.scss', 'public/css')
-   ;
+   .sass('resources/assets/sass/app.scss', 'public/css');
+
+// in production
+if (mix.config.inProduction) {
+    mix.version();
+}
+
+// in production at laravel-mix ^1.0.0
+// if (mix.inProduction()) {
+//     mix.version();
+// }


### PR DESCRIPTION
- Use to `mix.version()` in production build.
- Resolved `element-ui-default` import.